### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
   "name": "koa-path-match",
   "description": "koa route middleware",
-  "version": "4.0.0",
+  "version": "4.0.0-lineaje-01",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "license": "MIT",
-  "repository": "koajs/path-match",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lineaje-labs-gos/path-match"
+  },
   "dependencies": {
     "lodash": "^4.17.21",
     "path-to-regexp": "^7.1.0"


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
